### PR TITLE
fix unsandboxed as root warning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deb-installer (23.8.02) mx; urgency=medium
+
+  * Fix: Download is performed unsandboxed as root
+
+ -- fehlix <fehlix@mxlinux.org>  Sat, 19 Aug 2023 20:35:24 -0400
+
 deb-installer (23.8.01) mx; urgency=medium
 
   * Re-add text prompting to elevate to install packages

--- a/installer.cpp
+++ b/installer.cpp
@@ -131,6 +131,7 @@ void Installer::install(const QStringList &file_names)
     const QString admincommand = QFile::exists("/usr/bin/pkexec") ? "pkexec" : QString("sudo -p '%1: '").arg(msg);
     cmd.run("x-terminal-emulator -e " + admincommand + " bash -c ' LANG=" + qEnvironmentVariable("LANG")
             + " DISPLAY=" + qEnvironmentVariable("DISPLAY") + " XAUTHORITY=" + qEnvironmentVariable("XAUTHORITY")
-            + " apt -o Acquire::AllowUnsizedPackages=true reinstall " + file_names.join(" ")
+            + " apt -o Acquire::AllowUnsizedPackages=true -o APT::Sandbox::User=root"
+            + " reinstall " + file_names.join(" ")
             + "; echo; read -n1 -srp \"" + tr("Press any key to close") + "\"'");
 }


### PR DESCRIPTION
This fixes the error/warning  "Download is performed unsandboxed as root as file ‘filename.deb’ couldn’t be accessed by user ‘_apt'. - pkgAcquire::Run (13: Permission denied)"